### PR TITLE
Removed Phys:Wake from SENTs

### DIFF
--- a/lua/entities/dak_crew/init.lua
+++ b/lua/entities/dak_crew/init.lua
@@ -18,11 +18,8 @@ function ENT:Initialize()
 	self:PhysicsInit(SOLID_VPHYSICS)
 	self:SetMoveType(MOVETYPE_VPHYSICS)
 	self:SetSolid(SOLID_VPHYSICS)
+
 	self.DakHealth = self.DakMaxHealth
-	local phys = self:GetPhysicsObject()
-	if(phys:IsValid()) then
-		phys:Wake()
-	end
 	self.Soundtime = CurTime()
  	self.SparkTime = CurTime()
  	self.DakBurnStacks = 0
@@ -74,7 +71,7 @@ function ENT:Think()
 	self.DakMaxHealth = 5
 	self.DakArmor = 2.5
 	self.DakMass = 75
-	--self.DakModel = "models/daktanks/crew.mdl"	
+	--self.DakModel = "models/daktanks/crew.mdl"
 	if self.DakHealth > self.DakMaxHealth then
 		self.DakHealth = self.DakMaxHealth
 	end
@@ -166,7 +163,7 @@ function ENT:PreEntityCopy()
 
 	//Wire dupe info
 	self.BaseClass.PreEntityCopy( self )
-	
+
 end
 
 function ENT:PostEntityPaste( Player, Ent, CreatedEntities )

--- a/lua/entities/dak_tankcore/init.lua
+++ b/lua/entities/dak_tankcore/init.lua
@@ -15,15 +15,10 @@ function ENT:Initialize()
 	self:PhysicsInit(SOLID_VPHYSICS)
 	self:SetMoveType(MOVETYPE_VPHYSICS)
 	self:SetSolid(SOLID_VPHYSICS)
+
 	self.DakHealth = self.DakMaxHealth
 	self.DakArmor = 10
-	local phys = self:GetPhysicsObject()
 	self.timer = CurTime()
-
-	if(IsValid(phys)) then
-		phys:Wake()
-	end
-
 	self.Outputs = WireLib.CreateOutputs( self, { "Health","HealthPercent","Crew" } )
 	self.Soundtime = CurTime()
  	self.SparkTime = CurTime()
@@ -87,7 +82,7 @@ end
 --[[
 local function GetParents(Ent)
     if not IsValid(Ent) then return end
-    
+
     local Table  = {[Ent] = true}
     local Parent = Ent:GetParent()
 
@@ -152,7 +147,7 @@ function ENT:Think()
 				if self.Cost and self.Cost>0 then
 					if not(self.CostTimerFirst) then
 						self.CostTimerFirst = CurTime()
-						self.CostTimer = 0	
+						self.CostTimer = 0
 					end
 					self.CostTimer = CurTime() - self.CostTimerFirst
 					if self.CostTimer > 5 then
@@ -174,7 +169,7 @@ function ENT:Think()
 						self:SetMoveType(MOVETYPE_VPHYSICS)
 						self:SetSolid(SOLID_VPHYSICS)
 					end
-					
+
 					if self.rebuildtable == nil or self.rebuildtable == 5 then --rebuild contraption table every 5 seconds instead of every second to notice weight changes.
 						self.rebuildtable = 0
 					end
@@ -552,14 +547,14 @@ function ENT:Think()
 							self.DamageCycle = 0
 							if self.DakHealth < self.CurrentHealth then
 								self.DamageCycle = self.DamageCycle+(self.CurrentHealth-self.DakHealth)
-								self.DakLastDamagePos = self.DakLastDamagePos	
+								self.DakLastDamagePos = self.DakLastDamagePos
 							end
 							self.Remake = 0
 							self.LastCurMass = self.CurMass
 							self.CurMass = 0
 							for i = 1, table.Count(self.HitBox) do
 								if self.HitBox[i].Controller ~= self then
-									self.Remake = 1	
+									self.Remake = 1
 								end
 								if self.Remake == 1 then
 									if self.HitBox[i].Controller == self then
@@ -575,7 +570,7 @@ function ENT:Think()
 												table.RemoveByValue( self.HitBox, NULL )
 											end
 											self.DamageCycle = self.DamageCycle+(self.CurrentHealth-self.HitBox[i].DakHealth)
-											self.DakLastDamagePos = self.HitBox[i].DakLastDamagePos	
+											self.DakLastDamagePos = self.HitBox[i].DakLastDamagePos
 										end
 									end
 								end
@@ -610,7 +605,7 @@ function ENT:Think()
 								self.HitBox[i].DakHealth = self.CurrentHealth
 							end
 							self.DakHealth = self.CurrentHealth
-							
+
 							local curvel = self:GetParent():GetParent():GetVelocity()
 							if self.LastVel == nil then
 								self.LastVel = curvel

--- a/lua/entities/dak_teammo/init.lua
+++ b/lua/entities/dak_teammo/init.lua
@@ -18,13 +18,8 @@ function ENT:Initialize()
 	self:SetMoveType(MOVETYPE_VPHYSICS)
 	self:SetSolid(SOLID_VPHYSICS)
 
-	local phys = self:GetPhysicsObject()
-
-	if(IsValid(phys)) then
-		phys:Wake()
-	end
 	--self.DakAmmo = self.DakMaxAmmo
-	
+
 	self.Inputs = Wire_CreateInputs(self, { "EjectAmmo" })
 	self.Outputs = WireLib.CreateOutputs( self, { "Ammo", "MaxAmmo" } )
 	self.Soundtime = CurTime()
@@ -143,7 +138,7 @@ function ENT:Think()
 					self.ShellVolume = self.ShellVolume*1.5
 				end
 				self.ShellMass = self.ShellVolume*0.044
-				if self.DakAmmo == nil then 
+				if self.DakAmmo == nil then
 					self.DakAmmo = self.DakMaxAmmo
 				end
 				if self.DakAmmo > self.DakMaxAmmo then
@@ -175,7 +170,7 @@ function ENT:Think()
 				self:GetPhysicsObject():SetMass(math.Round((self.ShellMass*self.DakAmmo)+10))
 			end
 		end
-		
+
 		WireLib.TriggerOutput(self, "Ammo", self.DakAmmo)
 		WireLib.TriggerOutput(self, "MaxAmmo", self.DakMaxAmmo)
 
@@ -244,7 +239,7 @@ function ENT:Think()
 									self:Remove()
 								end
 							end
-						end)		
+						end)
 						timer.Create( "AmmoBurnTimer"..self:EntIndex(), 0.25, 100, function()
 							if not(self.DakAmmo == nil) then
 								if self.DakAmmo > 0 then
@@ -332,7 +327,7 @@ function ENT:Think()
 			self:Remove()
 		end
 	end
-	
+
 	self:NextThink( CurTime()+0.1 )
     return true
 end
@@ -358,7 +353,7 @@ function ENT:PreEntityCopy()
 
 	//Wire dupe info
 	self.BaseClass.PreEntityCopy( self )
-	
+
 end
 
 function ENT:PostEntityPaste( Player, Ent, CreatedEntities )
@@ -423,7 +418,7 @@ function ENT:PostEntityPaste( Player, Ent, CreatedEntities )
 			self.ShellVolume = self.ShellVolume*1.5
 		end
 		self.ShellMass = self.ShellVolume*0.044
-		if self.DakAmmo == nil then 
+		if self.DakAmmo == nil then
 			self.DakAmmo = self.DakMaxAmmo
 		end
 		if self.DakAmmo > self.DakMaxAmmo then
@@ -436,7 +431,7 @@ end
 
 function ENT:CheckClip(Ent, HitPos)
 	if not (Ent:GetClass() == "prop_physics") or (Ent.ClipData == nil) then return false end
-	
+
 	local HitClip = false
 	local normal
 	local origin
@@ -465,7 +460,7 @@ function ENT:DTExplosion(Pos,Damage,Radius,Caliber,Pen,Owner)
 		if ExpTrace.Entity:IsValid() then
 			if ExpTrace.Entity:GetClass() == self:GetClass() then
 				ExpTrace.Entity =  NULL
-			end 
+			end
 		end
 		if hook.Run("DakTankDamageCheck", ExpTrace.Entity, Owner) ~= false and ExpTrace.HitPos:Distance(Pos)<=Radius then
 			--decals don't like using the adjusted by normal Pos
@@ -484,7 +479,7 @@ function ENT:DTExplosion(Pos,Damage,Radius,Caliber,Pen,Owner)
 							ExpTrace.Entity.DakArmor = ExpTrace.Entity:OBBMaxs().x/2
 							ExpTrace.Entity.DakIsTread = 1
 						else
-							if ExpTrace.Entity:GetClass()=="prop_physics" then 
+							if ExpTrace.Entity:GetClass()=="prop_physics" then
 								DTArmorSanityCheck(ExpTrace.Entity)
 							end
 						end
@@ -503,16 +498,16 @@ function ENT:DTExplosion(Pos,Damage,Radius,Caliber,Pen,Owner)
 							ExpTrace.Entity.DakArmor = ExpTrace.Entity:OBBMaxs().x/2
 							ExpTrace.Entity.DakIsTread = 1
 						else
-							if ExpTrace.Entity:GetClass()=="prop_physics" then 
+							if ExpTrace.Entity:GetClass()=="prop_physics" then
 								DTArmorSanityCheck(ExpTrace.Entity)
 							end
 						end
 					end
-					
+
 					ExpTrace.Entity.DakLastDamagePos = ExpTrace.HitPos
 
-					if not(ExpTrace.Entity.SPPOwner==nil) and not(ExpTrace.Entity.SPPOwner:IsWorld()) then			
-						if ExpTrace.Entity.SPPOwner:HasGodMode()==false and ExpTrace.Entity.DakIsTread == nil then	
+					if not(ExpTrace.Entity.SPPOwner==nil) and not(ExpTrace.Entity.SPPOwner:IsWorld()) then
+						if ExpTrace.Entity.SPPOwner:HasGodMode()==false and ExpTrace.Entity.DakIsTread == nil then
 							ExpTrace.Entity.DakHealth = ExpTrace.Entity.DakHealth- (Damage/traces)*2*(Pen/ExpTrace.Entity.DakArmor)
 						end
 					else
@@ -569,7 +564,7 @@ function ENT:DTExplosion(Pos,Damage,Radius,Caliber,Pen,Owner)
 				if not(ExpTrace.Entity:GetParent():IsValid()) then
 					ExpTrace.Entity:GetPhysicsObject():ApplyForceCenter( 0.01*(ExpTrace.HitPos-Pos):GetNormalized()*(Damage/traces)*35*ExpTrace.Entity:GetPhysicsObject():GetMass()*(1-(ExpTrace.HitPos:Distance(Pos)/1000))  )
 				end
-			end		
+			end
 		end
 	end
 end
@@ -588,7 +583,7 @@ function ENT:DamageEXP(Filter,IgnoreEnt,Pos,Damage,Radius,Caliber,Pen,Owner,Dire
 	if ExpTrace.Entity:IsValid() then
 		if ExpTrace.Entity:GetClass() == self:GetClass() then
 			ExpTrace.Entity =  NULL
-		end 
+		end
 	end
 
 	if hook.Run("DakTankDamageCheck", ExpTrace.Entity, Owner) ~= false and ExpTrace.HitPos:Distance(Pos)<=Radius then
@@ -608,7 +603,7 @@ function ENT:DamageEXP(Filter,IgnoreEnt,Pos,Damage,Radius,Caliber,Pen,Owner,Dire
 						ExpTrace.Entity.DakArmor = ExpTrace.Entity:OBBMaxs().x/2
 						ExpTrace.Entity.DakIsTread = 1
 					else
-						if ExpTrace.Entity:GetClass()=="prop_physics" then 
+						if ExpTrace.Entity:GetClass()=="prop_physics" then
 							DTArmorSanityCheck(ExpTrace.Entity)
 						end
 					end
@@ -627,15 +622,15 @@ function ENT:DamageEXP(Filter,IgnoreEnt,Pos,Damage,Radius,Caliber,Pen,Owner,Dire
 						ExpTrace.Entity.DakArmor = ExpTrace.Entity:OBBMaxs().x/2
 						ExpTrace.Entity.DakIsTread = 1
 					else
-						if ExpTrace.Entity:GetClass()=="prop_physics" then 
+						if ExpTrace.Entity:GetClass()=="prop_physics" then
 							DTArmorSanityCheck(ExpTrace.Entity)
 						end
 					end
 				end
-				
+
 				ExpTrace.Entity.DakLastDamagePos = ExpTrace.HitPos
 
-				if not(ExpTrace.Entity.SPPOwner==nil) and not(ExpTrace.Entity.SPPOwner:IsWorld()) then			
+				if not(ExpTrace.Entity.SPPOwner==nil) and not(ExpTrace.Entity.SPPOwner:IsWorld()) then
 					if ExpTrace.Entity.SPPOwner:HasGodMode()==false and ExpTrace.Entity.DakIsTread == nil then
 						ExpTrace.Entity.DakHealth = ExpTrace.Entity.DakHealth- (Damage/traces)*2*(Pen/ExpTrace.Entity.DakArmor)
 					end
@@ -692,7 +687,7 @@ function ENT:DamageEXP(Filter,IgnoreEnt,Pos,Damage,Radius,Caliber,Pen,Owner,Dire
 			if not(ExpTrace.Entity:GetParent():IsValid()) then
 				ExpTrace.Entity:GetPhysicsObject():ApplyForceCenter( 0.01*(ExpTrace.HitPos-Pos):GetNormalized()*(Damage/traces)*35*ExpTrace.Entity:GetPhysicsObject():GetMass()*(1-(ExpTrace.HitPos:Distance(Pos)/1000))  )
 			end
-		end		
+		end
 	end
 end
 ]]--

--- a/lua/entities/dak_teautogun/init.lua
+++ b/lua/entities/dak_teautogun/init.lua
@@ -40,16 +40,12 @@ ENT.BasicVelocity = 29527.6
 function ENT:Initialize()
 	--self:SetModel(self.DakModel)
 	self.DakHealth = self.DakMaxHealth
-	
+
 	self:PhysicsInit(SOLID_VPHYSICS)
 	self:SetMoveType(MOVETYPE_VPHYSICS)
 	self:SetSolid(SOLID_VPHYSICS)
 
-	local phys = self:GetPhysicsObject()
 	self.timer = CurTime()
-	if(IsValid(phys)) then
-		phys:Wake()
-	end
 	self.Inputs = Wire_CreateInputs(self, { "Fire", "SwapAmmo","Reload", "Indicator [ENTITY]" })
 	self.Outputs = WireLib.CreateOutputs( self, { "Cooldown" , "CooldownPercent", "MaxCooldown", "ReloadTime", "Ammo", "MagazineRounds", "AmmoType [STRING]", "MuzzleVel", "ShellMass", "Penetration" } )
  	self.Held = false
@@ -84,7 +80,7 @@ function ENT:Think()
 			self.DakMaxHealth = self.DakCaliber
 			self.DakArmor = self.DakCaliber*5
 			self.DakMass = math.Round(((((self.DakCaliber*6.5)*(self.DakCaliber*3)*(self.DakCaliber*3))+(math.pi*(self.DakCaliber^2)*(self.DakCaliber*50))-(math.pi*((self.DakCaliber/2)^2)*(self.DakCaliber*50)))*0.001*7.8125)/1000)
-			
+
 			self.DakAP = math.Round(self.DakCaliber,2).."mmCAPAmmo"
 			self.DakHE = math.Round(self.DakCaliber,2).."mmCHEAmmo"
 			self.DakHEAT = math.Round(self.DakCaliber,2).."mmCHEATAmmo"
@@ -155,7 +151,7 @@ function ENT:Think()
 					self.DakFireSound1 = "daktanks/c200.wav"
 				end
 			end
-			
+
 			self.IsAutoLoader = 1
 		end
 		if self.DakGunType == "Long Autoloader" then
@@ -233,7 +229,7 @@ function ENT:Think()
 					self.DakFireSound1 = "daktanks/c200.wav"
 				end
 			end
-			
+
 			self.IsAutoLoader = 1
 		end
 		if self.DakGunType == "Short Autoloader" then
@@ -312,7 +308,7 @@ function ENT:Think()
 					self.DakFireSound1 = "daktanks/c200.wav"
 				end
 			end
-			
+
 			self.IsAutoLoader = 1
 		end
 		if self.DakGunType == "Autoloading Howitzer" then
@@ -387,7 +383,7 @@ function ENT:Think()
 					self.DakFireSound1 = "daktanks/h420.wav"
 				end
 			end
-			
+
 			self.IsAutoLoader = 1
 		end
 		if self.DakGunType == "Autoloading Mortar" then
@@ -463,7 +459,7 @@ function ENT:Think()
 					self.DakFireSound1 = "daktanks/m600.wav"
 				end
 			end
-			
+
 			self.IsAutoLoader = 1
 		end
 
@@ -1282,7 +1278,7 @@ function ENT:DakTEAutoAmmoCheck()
 		WireLib.TriggerOutput(self, "Penetration", self.DakShellPenetration)
 	end
 	if IsValid(self.DakTankCore) then
-		self.AmmoCount = 0 
+		self.AmmoCount = 0
 		self.SortedAmmo = {}
 		if not(self.DakTankCore.Ammoboxes == nil) then
 			for i = 1, #self.DakTankCore.Ammoboxes do
@@ -1309,7 +1305,7 @@ end
 function ENT:DakTEAutoFire()
 	if self.Firing and self.DakIsReloading==0 and self.Loaded==1 then
 		if IsValid(self.DakTankCore) then
-			self.AmmoCount = 0 
+			self.AmmoCount = 0
 			if not(self.SortedAmmo == nil) then
 				for i = 1, #self.SortedAmmo do
 					if IsValid(self.SortedAmmo[i][1]) then
@@ -1343,7 +1339,7 @@ function ENT:DakTEAutoFire()
 					end
 				end
 				local shootDir = shootAngles:Forward()
-				
+
 				local Propellant = self:GetPropellant()*0.01
  				local Shell = {}
  				Shell.Pos = shootOrigin + ( self:GetForward() * 1 )
@@ -1370,7 +1366,7 @@ function ENT:DakTEAutoFire()
 				end
 				if self.CurrentAmmoType == 8 then
 					Shell.DakCaliber = self.DakMaxHealth/4
-				end			
+				end
 				Shell.DakFireSound = self.DakFireSound1
 				Shell.DakFirePitch = self.DakFirePitch
 				Shell.DakGun = self
@@ -1469,7 +1465,7 @@ function ENT:DakTEAutoFire()
 		end
 	end
 	if IsValid(self.DakTankCore) then
-		self.AmmoCount = 0 
+		self.AmmoCount = 0
 		if not(self.DakTankCore.Ammoboxes == nil) then
 			for i = 1, #self.DakTankCore.Ammoboxes do
 				if IsValid(self.DakTankCore.Ammoboxes[i]) then
@@ -1666,7 +1662,7 @@ function ENT:DakTEAutoGunAmmoSwap()
 		WireLib.TriggerOutput(self, "Penetration", self.DakShellPenetration)
 	end
 	if IsValid(self.DakTankCore) then
-		self.AmmoCount = 0 
+		self.AmmoCount = 0
 		if not(self.DakTankCore.Ammoboxes == nil) then
 			for i = 1, #self.DakTankCore.Ammoboxes do
 				if IsValid(self.DakTankCore.Ammoboxes[i]) then
@@ -1764,7 +1760,7 @@ function ENT:PreEntityCopy()
 
 	//Wire dupe info
 	self.BaseClass.PreEntityCopy( self )
-	
+
 end
 
 function ENT:PostEntityPaste( Player, Ent, CreatedEntities )

--- a/lua/entities/dak_teautoloadingmodule/init.lua
+++ b/lua/entities/dak_teautoloadingmodule/init.lua
@@ -17,11 +17,6 @@ function ENT:Initialize()
 	self:SetMoveType(MOVETYPE_VPHYSICS)
 	self:SetSolid(SOLID_VPHYSICS)
 
-	local phys = self:GetPhysicsObject()
-
-	if(IsValid(phys)) then
-		phys:Wake()
-	end
 	self.DakArmor = 10
 	self.DakMass = 1000
 	self.Soundtime = CurTime()
@@ -30,7 +25,7 @@ function ENT:Initialize()
  	if self.DakHealth>self.DakMaxHealth then
 		self.DakHealth = self.DakMaxHealth
 	end
- 	
+
 	self.DakBurnStacks = 0
 end
 
@@ -91,13 +86,13 @@ function ENT:Think()
 		self.SparkTime=CurTime()
 	end
 		if self.DakName == "Small Autoloader Clip" then
-			self.DakName = "Small Autoloader Magazine" 
+			self.DakName = "Small Autoloader Magazine"
 		end
 		if self.DakName == "Medium Autoloader Clip" then
-			self.DakName = "Medium Autoloader Magazine" 
+			self.DakName = "Medium Autoloader Magazine"
 		end
 		if self.DakName == "Large Autoloader Clip" then
-			self.DakName = "Large Autoloader Magazine" 
+			self.DakName = "Large Autoloader Magazine"
 		end
 		if self.DakName == "Small Autoloader Magazine" then
 			self.DakMass = 1000
@@ -219,7 +214,7 @@ end
 
 function ENT:CheckClip(Ent, HitPos)
 	if not (Ent:GetClass() == "prop_physics") or (Ent.ClipData == nil) then return false end
-	
+
 	local HitClip = false
 	local normal
 	local origin
@@ -248,7 +243,7 @@ function ENT:DTExplosion(Pos,Damage,Radius,Caliber,Pen,Owner)
 		if ExpTrace.Entity:IsValid() then
 			if ExpTrace.Entity:GetClass() == self:GetClass() then
 				ExpTrace.Entity =  NULL
-			end 
+			end
 		end
 		if hook.Run("DakTankDamageCheck", ExpTrace.Entity, Owner) ~= false and ExpTrace.HitPos:Distance(Pos)<=Radius then
 			--decals don't like using the adjusted by normal Pos
@@ -267,7 +262,7 @@ function ENT:DTExplosion(Pos,Damage,Radius,Caliber,Pen,Owner)
 							ExpTrace.Entity.DakArmor = ExpTrace.Entity:OBBMaxs().x/2
 							ExpTrace.Entity.DakIsTread = 1
 						else
-							if ExpTrace.Entity:GetClass()=="prop_physics" then 
+							if ExpTrace.Entity:GetClass()=="prop_physics" then
 								DTArmorSanityCheck(ExpTrace.Entity)
 							end
 						end
@@ -286,16 +281,16 @@ function ENT:DTExplosion(Pos,Damage,Radius,Caliber,Pen,Owner)
 							ExpTrace.Entity.DakArmor = ExpTrace.Entity:OBBMaxs().x/2
 							ExpTrace.Entity.DakIsTread = 1
 						else
-							if ExpTrace.Entity:GetClass()=="prop_physics" then 
+							if ExpTrace.Entity:GetClass()=="prop_physics" then
 								DTArmorSanityCheck(ExpTrace.Entity)
 							end
 						end
 					end
-					
+
 					ExpTrace.Entity.DakLastDamagePos = ExpTrace.HitPos
 
-					if not(ExpTrace.Entity.SPPOwner==nil) then			
-						if ExpTrace.Entity.SPPOwner:HasGodMode()==false and ExpTrace.Entity.DakIsTread == nil then	
+					if not(ExpTrace.Entity.SPPOwner==nil) then
+						if ExpTrace.Entity.SPPOwner:HasGodMode()==false and ExpTrace.Entity.DakIsTread == nil then
 							ExpTrace.Entity.DakHealth = ExpTrace.Entity.DakHealth- (Damage/traces)*2*(Pen/ExpTrace.Entity.DakArmor)
 						end
 					else
@@ -350,7 +345,7 @@ function ENT:DTExplosion(Pos,Damage,Radius,Caliber,Pen,Owner)
 				if not(ExpTrace.Entity:GetParent():IsValid()) then
 					ExpTrace.Entity:GetPhysicsObject():ApplyForceCenter( (ExpTrace.HitPos-Pos):GetNormalized()*(Damage/traces)*35*ExpTrace.Entity:GetPhysicsObject():GetMass()*(1-(ExpTrace.HitPos:Distance(Pos)/1000))  )
 				end
-			end		
+			end
 		end
 	end
 end
@@ -369,7 +364,7 @@ function ENT:DamageEXP(Filter,IgnoreEnt,Pos,Damage,Radius,Caliber,Pen,Owner,Dire
 	if ExpTrace.Entity:IsValid() then
 		if ExpTrace.Entity:GetClass() == self:GetClass() then
 			ExpTrace.Entity =  NULL
-		end 
+		end
 	end
 
 	if hook.Run("DakTankDamageCheck", ExpTrace.Entity, Owner) ~= false and ExpTrace.HitPos:Distance(Pos)<=Radius then
@@ -389,7 +384,7 @@ function ENT:DamageEXP(Filter,IgnoreEnt,Pos,Damage,Radius,Caliber,Pen,Owner,Dire
 						ExpTrace.Entity.DakArmor = ExpTrace.Entity:OBBMaxs().x/2
 						ExpTrace.Entity.DakIsTread = 1
 					else
-						if ExpTrace.Entity:GetClass()=="prop_physics" then 
+						if ExpTrace.Entity:GetClass()=="prop_physics" then
 							DTArmorSanityCheck(ExpTrace.Entity)
 						end
 					end
@@ -408,16 +403,16 @@ function ENT:DamageEXP(Filter,IgnoreEnt,Pos,Damage,Radius,Caliber,Pen,Owner,Dire
 						ExpTrace.Entity.DakArmor = ExpTrace.Entity:OBBMaxs().x/2
 						ExpTrace.Entity.DakIsTread = 1
 					else
-						if ExpTrace.Entity:GetClass()=="prop_physics" then 
+						if ExpTrace.Entity:GetClass()=="prop_physics" then
 							DTArmorSanityCheck(ExpTrace.Entity)
 						end
 					end
 				end
-				
+
 				ExpTrace.Entity.DakLastDamagePos = ExpTrace.HitPos
 
-				if not(ExpTrace.Entity.SPPOwner==nil) then			
-					if ExpTrace.Entity.SPPOwner:HasGodMode()==false and ExpTrace.Entity.DakIsTread == nil then	
+				if not(ExpTrace.Entity.SPPOwner==nil) then
+					if ExpTrace.Entity.SPPOwner:HasGodMode()==false and ExpTrace.Entity.DakIsTread == nil then
 						ExpTrace.Entity.DakHealth = ExpTrace.Entity.DakHealth- (Damage/traces)*2*(Pen/ExpTrace.Entity.DakArmor)
 					end
 				else
@@ -471,6 +466,6 @@ function ENT:DamageEXP(Filter,IgnoreEnt,Pos,Damage,Radius,Caliber,Pen,Owner,Dire
 			if not(ExpTrace.Entity:GetParent():IsValid()) then
 				ExpTrace.Entity:GetPhysicsObject():ApplyForceCenter( (ExpTrace.HitPos-Pos):GetNormalized()*(Damage/traces)*35*ExpTrace.Entity:GetPhysicsObject():GetMass()*(1-(ExpTrace.HitPos:Distance(Pos)/1000))  )
 			end
-		end		
+		end
 	end
 end

--- a/lua/entities/dak_tefuel/init.lua
+++ b/lua/entities/dak_tefuel/init.lua
@@ -31,11 +31,6 @@ function ENT:Initialize()
 	self:SetMoveType(MOVETYPE_VPHYSICS)
 	self:SetSolid(SOLID_VPHYSICS)
 
-	local phys = self:GetPhysicsObject()
-
-	if(IsValid(phys)) then
-		phys:Wake()
-	end
 	self.DakArmor = 10
 	self.DakMass = 1000
 	self.PowerMod = 1
@@ -46,7 +41,7 @@ function ENT:Initialize()
  	if self.DakHealth>self.DakMaxHealth then
 		self.DakHealth = self.DakMaxHealth
 	end
- 	
+
 	self.DakBurnStacks = 0
 end
 
@@ -227,7 +222,7 @@ function ENT:PreEntityCopy()
 
 	//Wire dupe info
 	self.BaseClass.PreEntityCopy( self )
-	
+
 end
 
 function ENT:PostEntityPaste( Player, Ent, CreatedEntities )

--- a/lua/entities/dak_tegearbox/init.lua
+++ b/lua/entities/dak_tegearbox/init.lua
@@ -19,12 +19,9 @@ function ENT:Initialize()
 	self:PhysicsInit(SOLID_VPHYSICS)
 	self:SetMoveType(MOVETYPE_VPHYSICS)
 	self:SetSolid(SOLID_VPHYSICS)
+
 	self.DakHealth = self.DakMaxHealth
 	self.DakSpeed = 2
-	local phys = self:GetPhysicsObject()
-	if(phys:IsValid()) then
-		phys:Wake()
-	end
 	self.Inputs = Wire_CreateInputs(self, { "Forward", "Reverse", "Left", "Right", "Brakes", "Activate", "LeftDriveWheel [ENTITY]" , "RightDriveWheel [ENTITY]", "CarTurning", "ForwardFacingEntity [ENTITY]" })
 	self.Soundtime = CurTime()
  	self.Perc = 0
@@ -221,7 +218,7 @@ function ENT:Think()
 		self.DakHealth = self.DakMaxHealth
 	end
 
-	if IsValid(self.DakTankCore) and IsValid(self.DakTankCore.Motors[1]) then 
+	if IsValid(self.DakTankCore) and IsValid(self.DakTankCore.Motors[1]) then
 		local GearRatio = self:GetGearRatio()*0.01
 		self.DakSpeed = 0
 		self.DakFuel = 0
@@ -394,9 +391,9 @@ function ENT:Think()
 			        		end
 		        			self.TopSpeed = self.TopSpeed/3
 						end
-							
+
 						local ForwardVal = self.ForwardEnt:GetForward():Distance(self.phy:GetVelocity():GetNormalized()) --if it is below one you are going forward, if it is above one you are reversing
-						if self.Speed < self.TopSpeed and math.abs(LPhys:GetAngleVelocity().y/6) < math.Clamp(1250*(self.Speed*1.5/self.TopSpeed),500,1000) and math.abs(RPhys:GetAngleVelocity().y/6) < math.Clamp(1250*(self.Speed*1.5/self.TopSpeed),500,1000) then			
+						if self.Speed < self.TopSpeed and math.abs(LPhys:GetAngleVelocity().y/6) < math.Clamp(1250*(self.Speed*1.5/self.TopSpeed),500,1000) and math.abs(RPhys:GetAngleVelocity().y/6) < math.Clamp(1250*(self.Speed*1.5/self.TopSpeed),500,1000) then
 							self.RBoost = 1
 						 	self.LBoost = 1
 						 		local Lmult = 1
@@ -474,7 +471,7 @@ function ENT:Think()
 
 							local LeftVel = math.Clamp( (3000/(math.abs(LPhys:GetAngleVelocity().y)/6))-0.99,1,5 )
 							local RightVel = math.Clamp( (3000/(math.abs(RPhys:GetAngleVelocity().y)/6))-0.99,1,5 )
-							
+
 							--(self.DakHP/(4.8*math.pi)/(self.RightDriveWheel:OBBMaxs().z/12))/2.20462 = KG = how much it moves in a minute
 							local GearBoost = 0
 							self.CurTopSpeed = 0
@@ -486,7 +483,7 @@ function ENT:Think()
 							local G3Speed = self.TopSpeed*0.75
 							local G4Speed = self.TopSpeed
 
-							
+
 							if self.Speed < G1Speed then
 								--self.Gear = 1
 								GearBoost = math.Clamp(self.TopSpeed/(self.Speed*4),0,8*math.abs(self.Perc))
@@ -522,7 +519,7 @@ function ENT:Think()
 							end
 
 							if self.Speed > 0 and self.Speed < G1Speed and not(self.Gear == 1) then
-								self.Gear = 1 
+								self.Gear = 1
 								if #self.DakTankCore.Motors>0 then
 									for i=1, #self.DakTankCore.Motors do
 										if IsValid(self.DakTankCore.Motors[i]) then
@@ -534,7 +531,7 @@ function ENT:Think()
 								end
 							end
 							if self.Speed > G1Speed and self.Speed < G2Speed and not(self.Gear == 2) then
-								self.Gear = 2 
+								self.Gear = 2
 								if #self.DakTankCore.Motors>0 then
 									for i=1, #self.DakTankCore.Motors do
 										if IsValid(self.DakTankCore.Motors[i]) then
@@ -594,7 +591,7 @@ function ENT:Think()
 
 						if math.abs(LPhys:GetAngleVelocity().y/6) < 1500 and math.abs(RPhys:GetAngleVelocity().y/6) < 1500 then
 							if self.CarTurning==0 then
-								local TorqueBoost = 0.15*self.HPperTon 
+								local TorqueBoost = 0.15*self.HPperTon
 								local LeftVel = math.Clamp( (3000/(math.abs(LPhys:GetAngleVelocity().y)/6))-0.99,1,5 )
 								local RightVel = math.Clamp( (3000/(math.abs(RPhys:GetAngleVelocity().y)/6))-0.99,1,5 )
 								if self.MoveLeft>0 or self.MoveRight>0 then
@@ -623,7 +620,7 @@ function ENT:Think()
 								self.MoveLeftOld = self.MoveLeft
 								if self.Speed > 10 then
 									if self.MoveLeft>0 and self.MoveRight==0 then
-										if self.MoveReverse>0 then 
+										if self.MoveReverse>0 then
 											if self.RightBrakesEnabled == 0 then
 												constraint.Weld( self.RightDriveWheel, self.base, 0, 0, 0, false, false )
 												self.RightBrakesEnabled = 1
@@ -638,7 +635,7 @@ function ENT:Think()
 										end
 									end
 									if self.MoveRight>0 and self.MoveLeft==0 then
-										if self.MoveReverse>0 then 
+										if self.MoveReverse>0 then
 											if self.LeftBrakesEnabled == 0 then
 												constraint.Weld( self.LeftDriveWheel, self.base, 0, 0, 0, false, false )
 												self.LeftBrakesEnabled = 1
@@ -760,8 +757,8 @@ function ENT:Think()
 		        	self.LastYaw = self.base:GetAngles().yaw
 		        end
 
-		        if #self.Prev>=5 then 
-		        	table.remove( self.Prev, 1 ) 
+		        if #self.Prev>=5 then
+		        	table.remove( self.Prev, 1 )
 		        end
 		        self.NewPos = self:GetPos()
 		        self.Dist = self.NewPos:Distance(self.PrevPos)
@@ -769,7 +766,7 @@ function ENT:Think()
 
 		        table.insert(self.Prev,1, ( (self.Dist/(CurTime()-self.Time))/(84480/1609) ) )
 		        self.Time = CurTime()
-		        if #self.Prev>=5 then 
+		        if #self.Prev>=5 then
 		        	self.Speed = ((self.Prev[1]+self.Prev[2]+self.Prev[3]+self.Prev[4]+self.Prev[5])/5)*3.6*5
 		        else
 		        	self.Speed = 0
@@ -835,7 +832,7 @@ function ENT:PreEntityCopy()
 
 	//Wire dupe info
 	self.BaseClass.PreEntityCopy( self )
-	
+
 end
 
 function ENT:PostEntityPaste( Player, Ent, CreatedEntities )

--- a/lua/entities/dak_tegun/init.lua
+++ b/lua/entities/dak_tegun/init.lua
@@ -35,16 +35,12 @@ ENT.BasicVelocity = 29527.6
 function ENT:Initialize()
 	--self:SetModel(self.DakModel)
 	self.DakHealth = self.DakMaxHealth
-	
+
 	self:PhysicsInit(SOLID_VPHYSICS)
 	self:SetMoveType(MOVETYPE_VPHYSICS)
 	self:SetSolid(SOLID_VPHYSICS)
 
-	local phys = self:GetPhysicsObject()
 	self.timer = CurTime()
-	if(IsValid(phys)) then
-		phys:Wake()
-	end
 	self.Inputs = Wire_CreateInputs(self, { "Fire", "SwapAmmo", "Indicator [ENTITY]" })
 	self.Outputs = WireLib.CreateOutputs( self, { "Cooldown" , "CooldownPercent", "MaxCooldown", "Ammo", "AmmoType [STRING]", "MuzzleVel", "ShellMass", "Penetration" } )
  	self.Held = false
@@ -495,7 +491,7 @@ function ENT:Think()
 		self:GetPhysicsObject():SetMass(self.DakMass)
 
 		self:DakTEAmmoCheck()
-		
+
 		self.SlowThinkTime = CurTime()
 	end
 	if CurTime()>=self.MidThinkTime+0.33 then
@@ -733,7 +729,7 @@ end
 function ENT:DakTEFire()
 	if( self.Firing ) then
 		if IsValid(self.DakTankCore) then
-			self.AmmoCount = 0 
+			self.AmmoCount = 0
 			if not(self.SortedAmmo == nil) then
 				for i = 1, #self.SortedAmmo do
 					if IsValid(self.SortedAmmo[i][1]) then
@@ -794,7 +790,7 @@ function ENT:DakTEFire()
 				end
 				if self.CurrentAmmoType == 8 or self.CurrentAmmoType == 10 then
 					Shell.DakCaliber = self.DakMaxHealth/4
-				end					
+				end
 				Shell.DakFireSound = self.DakFireSound1
 				Shell.DakFirePitch = self.DakFirePitch
 				Shell.DakGun = self
@@ -852,7 +848,7 @@ function ENT:DakTEFire()
 				util.Effect( self.DakFireEffect, effectdata, true, true)
 				--self:EmitSound( self.DakFireSound1, 100, self.DakFirePitch, 1, 6)
 				self.timer = CurTime()
-				
+
 				if self.DakAmmoType == self.DakATGM then
 					if(self:IsValid()) then
 						if(self.DakTankCore:GetParent():IsValid()) then
@@ -880,7 +876,7 @@ function ENT:DakTEFire()
 		end
 	end
 	if IsValid(self.DakTankCore) then
-		self.AmmoCount = 0 
+		self.AmmoCount = 0
 		if not(self.DakTankCore.Ammoboxes == nil) then
 			for i = 1, #self.DakTankCore.Ammoboxes do
 				if IsValid(self.DakTankCore.Ammoboxes[i]) then
@@ -1078,7 +1074,7 @@ function ENT:DakTEGunAmmoSwap()
 		WireLib.TriggerOutput(self, "Penetration", self.DakShellPenetration)
 	end
 	if IsValid(self.DakTankCore) then
-		self.AmmoCount = 0 
+		self.AmmoCount = 0
 		if not(self.DakTankCore.Ammoboxes == nil) then
 			for i = 1, #self.DakTankCore.Ammoboxes do
 				if IsValid(self.DakTankCore.Ammoboxes[i]) then
@@ -1150,7 +1146,7 @@ function ENT:PreEntityCopy()
 
 	//Wire dupe info
 	self.BaseClass.PreEntityCopy( self )
-	
+
 end
 
 function ENT:PostEntityPaste( Player, Ent, CreatedEntities )

--- a/lua/entities/dak_temachinegun/init.lua
+++ b/lua/entities/dak_temachinegun/init.lua
@@ -35,16 +35,12 @@ ENT.BasicVelocity = 29527.6
 function ENT:Initialize()
 	--self:SetModel(self.DakModel)
 	self.DakHealth = self.DakMaxHealth
-	
+
 	self:PhysicsInit(SOLID_VPHYSICS)
 	self:SetMoveType(MOVETYPE_VPHYSICS)
 	self:SetSolid(SOLID_VPHYSICS)
 
-	local phys = self:GetPhysicsObject()
 	self.timer = CurTime()
-	if(IsValid(phys)) then
-		phys:Wake()
-	end
 	self.Inputs = Wire_CreateInputs(self, { "Fire" })
 	self.Outputs = WireLib.CreateOutputs( self, { "Cooldown" , "CooldownPercent", "MaxCooldown", "Ammo", "AmmoType [STRING]", "MuzzleVel", "ShellMass", "Penetration" } )
  	self.Held = false
@@ -208,7 +204,7 @@ function ENT:DakTEAmmoCheck()
 		WireLib.TriggerOutput(self, "Penetration", self.DakShellPenetration)
 	end
 	if IsValid(self.DakTankCore) then
-		self.AmmoCount = 0 
+		self.AmmoCount = 0
 		if not(self.DakTankCore.Ammoboxes == nil) then
 			for i = 1, #self.DakTankCore.Ammoboxes do
 				if IsValid(self.DakTankCore.Ammoboxes[i]) then
@@ -225,7 +221,7 @@ end
 function ENT:DakTEFire()
 	if( self.Firing ) then
 		if IsValid(self.DakTankCore) then
-			self.AmmoCount = 0 
+			self.AmmoCount = 0
 			if not(self.DakTankCore.Ammoboxes == nil) then
 				for i = 1, #self.DakTankCore.Ammoboxes do
 					if IsValid(self.DakTankCore.Ammoboxes[i]) then
@@ -313,7 +309,7 @@ function ENT:DakTEFire()
 				else
 					sound.Play( FiringSound[math.random(1,3)], self:GetPos(), 100, 100, 1 )
 				end
-								
+
 
 				local effectdata = EffectData()
 				effectdata:SetOrigin( self:GetAttachment( 1 ).Pos )
@@ -338,7 +334,7 @@ function ENT:DakTEFire()
 		end
 	end
 	if IsValid(self.DakTankCore) then
-		self.AmmoCount = 0 
+		self.AmmoCount = 0
 		if not(self.DakTankCore.Ammoboxes == nil) then
 			for i = 1, #self.DakTankCore.Ammoboxes do
 				if IsValid(self.DakTankCore.Ammoboxes[i]) then
@@ -395,7 +391,7 @@ function ENT:PreEntityCopy()
 
 	//Wire dupe info
 	self.BaseClass.PreEntityCopy( self )
-	
+
 end
 
 function ENT:PostEntityPaste( Player, Ent, CreatedEntities )
@@ -416,7 +412,7 @@ function ENT:PostEntityPaste( Player, Ent, CreatedEntities )
 			self.DakFireSound2 = Ent.EntityMods.DakTek.DakFireSound2
 			self.DakFireSound3 = Ent.EntityMods.DakTek.DakFireSound3
 		end
-		
+
 
 		self.DakOwner = Player
 		self:SetColor(Ent.EntityMods.DakTek.DakColor)
@@ -435,13 +431,13 @@ end
 --[[
 function GetAncestor ( Entity )
     if not IsValid(Entity) return end
-    
+
     local Parent = Entity
-    
+
     while Parent:GetParent() do
         Parent = Parent:GetParent()
     end
-    
+
     return Parent
 end
 ]]--

--- a/lua/entities/dak_temotor/init.lua
+++ b/lua/entities/dak_temotor/init.lua
@@ -21,11 +21,8 @@ function ENT:Initialize()
 	self:PhysicsInit(SOLID_VPHYSICS)
 	self:SetMoveType(MOVETYPE_VPHYSICS)
 	self:SetSolid(SOLID_VPHYSICS)
+
 	self.DakHealth = self.DakMaxHealth
-	local phys = self:GetPhysicsObject()
-	if(phys:IsValid()) then
-		phys:Wake()
-	end
 	--self:EmitSound(self.DakSound,75,0,1,CHAN_AUTO)
 	self.initsound = self.DakSound
 	self.Sound = CreateSound( self, self.DakSound, CReliableBroadcastRecipientFilter )
@@ -217,7 +214,7 @@ function ENT:PreEntityCopy()
 
 	//Wire dupe info
 	self.BaseClass.PreEntityCopy( self )
-	
+
 end
 
 function ENT:PostEntityPaste( Player, Ent, CreatedEntities )

--- a/lua/entities/dak_turretcontrol/init.lua
+++ b/lua/entities/dak_turretcontrol/init.lua
@@ -25,7 +25,7 @@ end
 --[[
 local function GetParents(Ent)
     if not IsValid(Ent) then return end
-    
+
     local Table  = {[Ent] = true}
     local Parent = Ent:GetParent()
 
@@ -122,15 +122,10 @@ function ENT:Initialize()
 	self:PhysicsInit(SOLID_VPHYSICS)
 	self:SetMoveType(MOVETYPE_VPHYSICS)
 	self:SetSolid(SOLID_VPHYSICS)
+
 	self.DakHealth = self.DakMaxHealth
 	self.DakArmor = 10
-	local phys = self:GetPhysicsObject()
 	self.timer = CurTime()
-
-	if(IsValid(phys)) then
-		phys:Wake()
-	end
-
 	self.Inputs = Wire_CreateInputs(self, { "Active", "Gun [ENTITY]", "Turret [ENTITY]", "CamTrace [RANGER]", "Lock" })
 	self.Soundtime = CurTime()
  	self.SparkTime = CurTime()
@@ -266,7 +261,7 @@ function ENT:Think()
 					self.RotationSpeed = RotMult * (15000/self.GunMass)
 					self.DakCamTrace = self.Inputs.CamTrace.Value
 					if (Class == "dak_tegun" or Class == "dak_teautogun" or Class == "dak_temachinegun") then
-						
+
 						if not(self.Inertia) then
 							self.Inertia = Angle(self.DakGun:GetPhysicsObject():GetInertia().y,self.DakGun:GetPhysicsObject():GetInertia().z,self.DakGun:GetPhysicsObject():GetInertia().x)
 						end
@@ -410,7 +405,7 @@ function ENT:PostEntityPaste( Player, Ent, CreatedEntities )
 		if Ent.EntityMods.DakTek.TurretMotorIDs then
 			if #Ent.EntityMods.DakTek.TurretMotorIDs > 0 then
 				for i = 1, #Ent.EntityMods.DakTek.TurretMotorIDs do
-					self.DakTurretMotors[#self.DakTurretMotors+1] = CreatedEntities[ Ent.EntityMods.DakTek.TurretMotorIDs[i] ] 
+					self.DakTurretMotors[#self.DakTurretMotors+1] = CreatedEntities[ Ent.EntityMods.DakTek.TurretMotorIDs[i] ]
 				end
 			end
 		end

--- a/lua/entities/dak_turretmotor/init.lua
+++ b/lua/entities/dak_turretmotor/init.lua
@@ -17,12 +17,9 @@ function ENT:Initialize()
 	self:PhysicsInit(SOLID_VPHYSICS)
 	self:SetMoveType(MOVETYPE_VPHYSICS)
 	self:SetSolid(SOLID_VPHYSICS)
+
 	self.DakArmor = 10
 	self.DakHealth = self.DakMaxHealth
-	local phys = self:GetPhysicsObject()
-	if(phys:IsValid()) then
-		phys:Wake()
-	end
 	self.Soundtime = CurTime()
  	self.SparkTime = CurTime()
  	self.DakBurnStacks = 0
@@ -95,19 +92,19 @@ function ENT:Think()
 	if self.DakName == "Small Turret Motor" then
 		self.DakMaxHealth = 10
 		self.DakMass = 250
-		self.DakModel = "models/xqm/hydcontrolbox.mdl"	
+		self.DakModel = "models/xqm/hydcontrolbox.mdl"
 		self.DakRotMult = 0.1
 	end
 	if self.DakName == "Medium Turret Motor" then
 		self.DakMaxHealth = 20
 		self.DakMass = 500
-		self.DakModel = "models/props_c17/utilityconducter001.mdl"	
+		self.DakModel = "models/props_c17/utilityconducter001.mdl"
 		self.DakRotMult = 0.25
 	end
 	if self.DakName == "Large Turret Motor" then
 		self.DakMaxHealth = 50
 		self.DakMass = 1000
-		self.DakModel = "models/props_c17/substation_transformer01d.mdl"	
+		self.DakModel = "models/props_c17/substation_transformer01d.mdl"
 		self.DakRotMult = 0.6
 	end
 	if self.DakModel then
@@ -161,7 +158,7 @@ function ENT:PreEntityCopy()
 
 	//Wire dupe info
 	self.BaseClass.PreEntityCopy( self )
-	
+
 end
 
 function ENT:PostEntityPaste( Player, Ent, CreatedEntities )


### PR DESCRIPTION
Removed Phys:Wake() from spawnable SENTs to fix issue with SENTs floating around when bumped after spawning.
Cleaned up trailing whitespace.