### PR TITLE
add additional wheel scale case

### DIFF
--- a/lua/entities/dak_tegearboxnew/cl_init.lua
+++ b/lua/entities/dak_tegearboxnew/cl_init.lua
@@ -393,6 +393,17 @@ local function setup_modelinfo(self, vehicleMode, dak_wheels_info)
 			scale2 = scale1*Vector(0.5, 1, 1)
 			rotate = Angle(0, 90, 0)
 
+		elseif obb.x > obb.z and obb.y > obb.z then
+			if hbb then
+				obb.x = hbb.x
+				obb.y = hbb.y
+				obb.z = hbb.z
+			end
+
+			scale1 = Vector(info.radius*2/obb.x, info.radius*2/obb.y, info.width/obb.z)
+			scale2 = scale1*Vector(1, 1, 0.5)
+			rotate = Angle(0, 0, -90)
+
 		else
 			scale1 = Vector(info.radius*2/obb.x, info.width/obb.y, info.radius*2/obb.z)
 			scale2 = scale1*Vector(1, 0.5, 1)


### PR DESCRIPTION
for when the wheel model is laying flat on the ground (scale.z > scale.x = scale.y)

a lot of the phx wheels are like this

![wheelzbugfix](https://user-images.githubusercontent.com/2807409/127742130-07bc7ee2-ed4d-46b5-821a-04f9559f1a06.png)
