### PR TITLE
Potential fix for penetrating particle error

### DIFF
--- a/lua/effects/dakteshellpenetrate/init.lua
+++ b/lua/effects/dakteshellpenetrate/init.lua
@@ -131,13 +131,9 @@ function EFFECT:Init( data )
 				particle:SetBounce(0)
 				particle:SetNextThink( CurTime() )
 				particle:SetThinkFunction( function( pa )
-					if pa~=NULL then
-						if HitEnt~=NULL and Attach~=nil then
-							if HitEnt~=NULL and Attach~=nil then
-								pa:SetPos( HitEnt:LocalToWorld(Attach) )
-							end
-							pa:SetNextThink( CurTime() )
-						end
+					if pa and HitEnt and Attach then
+						pa:SetPos( HitEnt:LocalToWorld(Attach) )
+						pa:SetNextThink( CurTime() )
 					end
 				end )
 			end


### PR DESCRIPTION
Might fix #26.

Removes the NULL and nil inequality checks for a more generic and safer evaluation.