### PR TITLE
Update to cl_distantsounds

### DIFF
--- a/lua/dtte/cl_distantsounds.lua
+++ b/lua/dtte/cl_distantsounds.lua
@@ -18,19 +18,20 @@ net.Receive( "daktankexplosion", function()
 
 	local Dist = PlayerPos:Distance(ExplosionPos)
 	local Vol = math.Clamp(math.pow( 0.5,PlayerPos:Distance(ExplosionPos) / (ExplosionPower * 50) ),0,1)
-	local SoundPos = LerpVector(0.4,PlayerPos,ExplosionPos)
 	if Vol > 0.01 then
-		timer.Simple(Dist / 18005, function()
-			if Dist < 8192 then
-				local LerpScale = math.min((Dist / 8192) * 1.5,1)
-				sound.Play( ExplosionSound, LerpVector(LerpScale,ExplosionPos,SoundPos), math.min(110 + (ExplosionPower / 7),165), 100, Vol)
-			else
-				local LerpScale = math.min(Dist / 32768,0.5)
-				sound.Play( ExplosionSound, LerpVector(LerpScale,SoundPos,PlayerPos), math.min(110 + (ExplosionPower / 7),165), 100, Vol)
+		timer.Simple(Dist / 13503.9, function()
+
+			local DistFresh = PlayerPos:Distance(ExplosionPos)
+			local PlayerPosFresh = LocalPlayer():EyePos()
+			local SoundDir = (ExplosionPos - PlayerPosFresh):GetNormalized()
+			local SoundPos = PlayerPosFresh + (SoundDir * math.Clamp(DistFresh,0,4096))
+
+			for i = 1,math.ceil(math.max(ExplosionPower / 80,1)) do
+				sound.Play( ExplosionSound, SoundPos, math.min(110 + (ExplosionPower / 7),165), 100, Vol)
 			end
 
 			if LocalPlayer():GetMoveType() ~= MOVETYPE_NOCLIP then
-				local Force = (ExplosionPower^1.2) / (Dist * 0.1)
+				local Force = (ExplosionPower^1.2) / (DistFresh * 0.1)
 				local Amp = (ExplosionPower / 10)
 				if (Force * 10) > 5 then util.ScreenShake( ExplosionPos, Amp * 1.2, Amp * 0.74, (ExplosionPower * 0.6) * 0.015, ExplosionPower^1.35 ) end
 			end
@@ -39,23 +40,26 @@ net.Receive( "daktankexplosion", function()
 end )
 
 net.Receive( "daktankshotfired", function()
-	local PlayerPos = LocalPlayer():EyePos()
 	local GunPos = net.ReadVector()
 	local Caliber = net.ReadFloat()
 	local GunSound = net.ReadString()
+	local PlayerPos = LocalPlayer():EyePos()
 	local Dist = PlayerPos:Distance(GunPos)
 	local Vol = math.Clamp(math.pow( 0.5,PlayerPos:Distance(GunPos) / (Caliber * 250) ),0,1)
-	local SoundPos = LerpVector(0.4,PlayerPos,GunPos)
+
 	if Vol > 0.01 then
-		timer.Simple(Dist / 18005, function()
-			if Dist < 8192 then
-				local LerpScale = math.min((Dist / 8192) * 1.5,1)
-				sound.Play( GunSound, LerpVector(LerpScale,GunPos,SoundPos), math.min(90 + (Caliber / 3),165), 100 * math.Rand(0.95,1.05), Vol)
-			else
-				local LerpScale = math.min(Dist / 32768,0.5)
-				sound.Play( GunSound, LerpVector(LerpScale,SoundPos,PlayerPos), math.min(90 + (Caliber / 3.5),165), 100 * math.Rand(0.95,1.05), Vol)
+		timer.Simple(Dist / 13503.9, function()
+
+			local PlayerPosFresh = LocalPlayer():EyePos()
+			local DistFresh = PlayerPosFresh:Distance(GunPos)
+			local SoundDir = (GunPos - PlayerPosFresh):GetNormalized()
+			local SoundPos = PlayerPosFresh + (SoundDir * math.Clamp(DistFresh,0,4096))
+
+			for i = 1,math.ceil(math.max(Caliber / 75,1)) do
+				sound.Play( GunSound, SoundPos, math.min(110 + (Caliber / 3),165), 100, Vol)
 			end
-			local Force = (35 * Caliber) / (Dist / 1.5)
+
+			local Force = (35 * Caliber) / (DistFresh / 2)
 			if LocalPlayer():GetMoveType() ~= MOVETYPE_NOCLIP and Force > 10 then
 				util.ScreenShake( GunPos, Force / 10, Force / 2, math.min(Force / 80,0.6), Force * 2.5 )
 			end

--- a/lua/dtte/cl_distantsounds.lua
+++ b/lua/dtte/cl_distantsounds.lua
@@ -1,48 +1,63 @@
 net.Receive( "daktankexplosion", function()
-	local PlayerPos = LocalPlayer():GetPos()
+	local PlayerPos = LocalPlayer():EyePos()
 	local ExplosionPos = net.ReadVector()
-	local ExplosionPower = net.ReadFloat()*0.5
-	local ExplosionSound = net.ReadString()
+	local ExplosionPower = net.ReadFloat() * 0.5
+	local ExplosionSound = net.ReadString() -- default sound is such a MASSIVE LET DOWN, so we're gonna use some extra stuff available ingame
+
+	if ExplosionPower <= 75 then
+		ExplosionSound = "daktanks/distexp1.mp3" -- WEAK
+	elseif ExplosionPower <= 100 then
+		ExplosionSound = "ambient/explosions/explode_1.wav"
+	elseif ExplosionPower <= 150 then
+		ExplosionSound = "ambient/explosions/explode_2.wav"
+	elseif ExplosionPower <= 300 then
+		ExplosionSound = "ambient/explosions/explode_5.wav"
+	else
+		ExplosionSound = "ambient/explosions/explode_6.wav"
+	end
+
 	local Dist = PlayerPos:Distance(ExplosionPos)
-	local Vol = math.Clamp(math.pow( 0.5,PlayerPos:Distance(ExplosionPos)/(ExplosionPower*50) ),0,1)
+	local Vol = math.Clamp(math.pow( 0.5,PlayerPos:Distance(ExplosionPos) / (ExplosionPower * 50) ),0,1)
+	local SoundPos = LerpVector(0.4,PlayerPos,ExplosionPos)
 	if Vol > 0.01 then
-		timer.Simple(Dist/13503.9, function()
-			local mult = math.Clamp(math.pow( 0.5,Dist/(ExplosionPower*250) ),0,1)
-			sound.Play(  ExplosionSound, PlayerPos+((ExplosionPos-PlayerPos):GetNormalized()*1000), 100, 100, Vol )
-			if LocalPlayer():GetMoveType()~=MOVETYPE_NOCLIP then
-				util.ScreenShake( ExplosionPos, mult*5, 5, (ExplosionPower*0.8)*0.025, 5000000 )
+		timer.Simple(Dist / 18005, function()
+			if Dist < 8192 then
+				local LerpScale = math.min((Dist / 8192) * 1.5,1)
+				sound.Play( ExplosionSound, LerpVector(LerpScale,ExplosionPos,SoundPos), math.min(110 + (ExplosionPower / 7),165), 100, Vol)
+			else
+				local LerpScale = math.min(Dist / 32768,0.5)
+				sound.Play( ExplosionSound, LerpVector(LerpScale,SoundPos,PlayerPos), math.min(110 + (ExplosionPower / 7),165), 100, Vol)
+			end
+
+			if LocalPlayer():GetMoveType() ~= MOVETYPE_NOCLIP then
+				local Force = (ExplosionPower^1.2) / (Dist * 0.1)
+				local Amp = (ExplosionPower / 10)
+				if (Force * 10) > 5 then util.ScreenShake( ExplosionPos, Amp * 1.2, Amp * 0.74, (ExplosionPower * 0.6) * 0.015, ExplosionPower^1.35 ) end
 			end
 		end)
 	end
 end )
 
 net.Receive( "daktankshotfired", function()
-
-	local PlayerPos = LocalPlayer():GetPos()
+	local PlayerPos = LocalPlayer():EyePos()
 	local GunPos = net.ReadVector()
 	local Caliber = net.ReadFloat()
 	local GunSound = net.ReadString()
 	local Dist = PlayerPos:Distance(GunPos)
-	local pitch = math.Rand(0.95, 1.05)
-	local Dir = LocalPlayer():GetPos()+((GunPos-LocalPlayer():GetPos()):GetNormalized()*1000)
-	local Vol = math.Clamp(math.pow( 0.5,PlayerPos:Distance(GunPos)/(Caliber*250) ),0,1)
+	local Vol = math.Clamp(math.pow( 0.5,PlayerPos:Distance(GunPos) / (Caliber * 250) ),0,1)
+	local SoundPos = LerpVector(0.4,PlayerPos,GunPos)
 	if Vol > 0.01 then
-		timer.Simple(Dist/13503.9, function()
-			sound.Play( GunSound, Dir, 100, 100*pitch, Vol )
-			if Caliber >= 75 then
-				sound.Play( GunSound, Dir, 100, 100*pitch, Vol )
+		timer.Simple(Dist / 18005, function()
+			if Dist < 8192 then
+				local LerpScale = math.min((Dist / 8192) * 1.5,1)
+				sound.Play( GunSound, LerpVector(LerpScale,GunPos,SoundPos), math.min(90 + (Caliber / 3),165), 100 * math.Rand(0.95,1.05), Vol)
+			else
+				local LerpScale = math.min(Dist / 32768,0.5)
+				sound.Play( GunSound, LerpVector(LerpScale,SoundPos,PlayerPos), math.min(90 + (Caliber / 3.5),165), 100 * math.Rand(0.95,1.05), Vol)
 			end
-			if Caliber >= 100 then
-				sound.Play( GunSound, Dir, 100, 100*pitch, Vol )
-			end
-			if Caliber >= 150 then
-				sound.Play( GunSound, Dir, 100, 100*pitch, Vol )
-			end
-			if Caliber >= 250 then
-				sound.Play( GunSound, Dir, 100, 100*pitch, Vol )
-			end
-			if LocalPlayer():GetMoveType()~=MOVETYPE_NOCLIP then
-				util.ScreenShake( GunPos, math.Clamp(math.pow( 0.5,LocalPlayer():GetPos():Distance(GunPos)/(50*Caliber) ),0,1) * 2.5, 2.5, Caliber/100, 5000000 )
+			local Force = (35 * Caliber) / (Dist / 1.5)
+			if LocalPlayer():GetMoveType() ~= MOVETYPE_NOCLIP and Force > 10 then
+				util.ScreenShake( GunPos, Force / 10, Force / 2, math.min(Force / 80,0.6), Force * 2.5 )
 			end
 		end)
 	end


### PR DESCRIPTION
Kinda overhauled how the distant sounds were done so they actually seemed distant
Previously if you moved when sounds played, it would sound as if it was happening right next to you, regardless of the battle happening on the other side of the map or not
Now, it'll play the sounds closer to where its occurring, and if its under a certain range be from the gun itself; the end effect being you can now travel around the map and have a clue where the battle is occurring just from sound alone